### PR TITLE
feat: add optional bearer auth and request hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Run the gRPC server (creates/applies SQLite migrations):
 export QUOTE_LEDGER_DB="${TMPDIR:-/tmp}/quote_ledger.db"
 # Optional: Prometheus scrape endpoint (default 127.0.0.1:9090)
 export METRICS_ADDR=127.0.0.1:9090
+# Optional: require `authorization: Bearer <token>` on ledger RPCs
+export QUOTE_LEDGER_AUTH_TOKEN=dev-local-token
 cargo run -- 127.0.0.1:50051
 ```
 
@@ -50,6 +52,14 @@ The process exposes **Prometheus** text exposition on **`GET /metrics`** (separa
 
 - **`METRICS_ADDR`**: `host:port` (default **`127.0.0.1:9090`**). Example scrape: `curl -s http://127.0.0.1:9090/metrics`.
 - Counters/gauges/histograms include in-flight append tracking (`quote_ledger_in_flight_appends`), append stream outcomes, subscribe opens, and append-one latency.
+
+### Auth (`QUOTE_LEDGER_AUTH_TOKEN`)
+
+When `QUOTE_LEDGER_AUTH_TOKEN` is set, `AppendCommands` and `SubscribeQuote` require gRPC metadata:
+
+- `authorization: Bearer <token>`
+- If unset, the service behaves as before (no auth gate).
+- Reflection remains enabled to preserve local exploration workflows.
 
 ### Shutdown
 
@@ -74,6 +84,10 @@ The server registers **gRPC reflection** (descriptor set from `build.rs`). With 
 ```bash
 grpcurl -plaintext localhost:50051 list
 grpcurl -plaintext localhost:50051 describe quote_ledger.v1.QuoteLedgerService
+
+# If auth is enabled:
+grpcurl -plaintext -H "authorization: Bearer ${QUOTE_LEDGER_AUTH_TOKEN}" \
+  localhost:50051 quote_ledger.v1.QuoteLedgerService/SubscribeQuote
 ```
 
 The server shuts down on **Ctrl+C** after **draining in-flight appends** (bounded wait), then `serve_with_shutdown` completes.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,71 @@
+use tonic::service::Interceptor;
+use tonic::{Request, Status};
+
+const AUTH_HEADER: &str = "authorization";
+
+#[derive(Clone, Debug)]
+pub struct AuthInterceptor {
+    expected_token: Option<String>,
+}
+
+impl AuthInterceptor {
+    pub fn from_env_var(var: &str) -> Result<Self, String> {
+        match std::env::var(var) {
+            Ok(token) => {
+                let trimmed = token.trim();
+                if trimmed.is_empty() {
+                    return Err(format!("{var} must not be empty when set"));
+                }
+                Ok(Self {
+                    expected_token: Some(trimmed.to_string()),
+                })
+            }
+            Err(std::env::VarError::NotPresent) => Ok(Self {
+                expected_token: None,
+            }),
+            Err(std::env::VarError::NotUnicode(_)) => Err(format!("{var} must be valid UTF-8")),
+        }
+    }
+
+    pub fn required(token: &str) -> Self {
+        Self {
+            expected_token: Some(token.to_string()),
+        }
+    }
+
+    fn check_request(&self, request: Request<()>) -> Result<Request<()>, Status> {
+        let Some(expected) = self.expected_token.as_ref() else {
+            return Ok(request);
+        };
+
+        let raw_header = request
+            .metadata()
+            .get(AUTH_HEADER)
+            .ok_or_else(|| Status::unauthenticated("missing authorization metadata"))?;
+
+        let raw = raw_header
+            .to_str()
+            .map_err(|_| Status::unauthenticated("authorization metadata is not valid ASCII"))?;
+
+        let (scheme, token) = raw
+            .split_once(' ')
+            .ok_or_else(|| Status::unauthenticated("invalid authorization metadata format"))?;
+
+        if !scheme.eq_ignore_ascii_case("bearer") {
+            return Err(Status::unauthenticated(
+                "authorization scheme must be Bearer",
+            ));
+        }
+        if token != expected {
+            return Err(Status::unauthenticated("invalid bearer token"));
+        }
+
+        Ok(request)
+    }
+}
+
+impl Interceptor for AuthInterceptor {
+    fn call(&mut self, request: Request<()>) -> Result<Request<()>, Status> {
+        self.check_request(request)
+    }
+}

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -26,6 +26,33 @@ use crate::v1::{
     QuoteTail, QuoteUpdate, StoredEvent, SubscribeQuoteRequest,
 };
 
+const MAX_ID_LEN: usize = 128;
+
+fn validate_identifier(field: &'static str, value: &str) -> Result<(), Status> {
+    if value.trim().is_empty() {
+        return Err(Status::invalid_argument(format!("{field} is required")));
+    }
+    if value.len() > MAX_ID_LEN {
+        return Err(Status::invalid_argument(format!(
+            "{field} exceeds {MAX_ID_LEN} characters"
+        )));
+    }
+    if value != value.trim() {
+        return Err(Status::invalid_argument(format!(
+            "{field} must not contain leading/trailing spaces"
+        )));
+    }
+    let valid = value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | ':' | '.'));
+    if !valid {
+        return Err(Status::invalid_argument(format!(
+            "{field} contains invalid characters"
+        )));
+    }
+    Ok(())
+}
+
 struct InFlightGuard {
     counter: Arc<AtomicUsize>,
 }
@@ -196,11 +223,8 @@ impl QuoteLedgerService for LedgerService {
                 Err(e) => return Err(e),
             };
 
-            if msg.client_command_id.is_empty() || msg.quote_id.is_empty() {
-                return Err(Status::invalid_argument(
-                    "client_command_id and quote_id are required",
-                ));
-            }
+            validate_identifier("client_command_id", &msg.client_command_id)?;
+            validate_identifier("quote_id", &msg.quote_id)?;
 
             match &quote_id {
                 None => quote_id = Some(msg.quote_id.clone()),
@@ -252,9 +276,7 @@ impl QuoteLedgerService for LedgerService {
         request: Request<SubscribeQuoteRequest>,
     ) -> Result<Response<Self::SubscribeQuoteStream>, Status> {
         let req = request.into_inner();
-        if req.quote_id.is_empty() {
-            return Err(Status::invalid_argument("quote_id is required"));
-        }
+        validate_identifier("quote_id", &req.quote_id)?;
 
         counter!("quote_ledger_subscribe_streams_total").increment(1);
         let inner = self.inner.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,13 @@ pub mod v1 {
 pub mod domain;
 pub mod sqlite;
 
+mod auth;
 mod error;
 mod ledger;
 mod mapping;
 mod store;
 
+pub use auth::AuthInterceptor;
 pub use error::StoreError;
 pub use ledger::{grpc_server, LedgerService};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,8 @@ use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use tonic::transport::Server;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 
-use quote_ledger::{grpc_server, sqlite, LedgerService, FILE_DESCRIPTOR_SET};
+use quote_ledger::v1::quote_ledger_service_server::QuoteLedgerServiceServer;
+use quote_ledger::{sqlite, AuthInterceptor, LedgerService, FILE_DESCRIPTOR_SET};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -52,9 +53,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let conn = sqlite::open_and_migrate(&db_path)?;
     tracing::info!(path = %db_path, "sqlite ready");
 
+    let auth = AuthInterceptor::from_env_var("QUOTE_LEDGER_AUTH_TOKEN")
+        .map_err(|e| format!("QUOTE_LEDGER_AUTH_TOKEN: {e}"))?;
+
     let ledger_service = LedgerService::new(conn);
     let in_flight = ledger_service.in_flight_counter();
-    let ledger = grpc_server(ledger_service);
+    let ledger = QuoteLedgerServiceServer::with_interceptor(ledger_service, auth);
 
     let reflection = ReflectionBuilder::configure()
         .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)

--- a/tests/auth_hardening.rs
+++ b/tests/auth_hardening.rs
@@ -1,0 +1,138 @@
+use std::time::Duration;
+
+use quote_ledger::v1::quote_command::Kind as CmdKind;
+use quote_ledger::v1::quote_ledger_service_client::QuoteLedgerServiceClient;
+use quote_ledger::v1::quote_ledger_service_server::QuoteLedgerServiceServer;
+use quote_ledger::v1::{AppendCommandRequest, CreateQuote, QuoteCommand, SubscribeQuoteRequest};
+use quote_ledger::{grpc_server, sqlite, AuthInterceptor, LedgerService};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::metadata::MetadataValue;
+use tonic::transport::Server;
+use tonic::Code;
+use tonic::Request;
+
+async fn start_server(auth: Option<&str>) -> String {
+    let dir = Box::leak(Box::new(tempfile::tempdir().expect("tempdir")));
+    let db = dir.path().join("auth.db");
+    let conn = sqlite::open_and_migrate(db.to_str().expect("utf8 path")).expect("migrate");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let incoming = TcpListenerStream::new(listener);
+
+    match auth {
+        Some(token) => {
+            let interceptor = AuthInterceptor::required(token);
+            let svc =
+                QuoteLedgerServiceServer::with_interceptor(LedgerService::new(conn), interceptor);
+            tokio::spawn(async move {
+                Server::builder()
+                    .add_service(svc)
+                    .serve_with_incoming(incoming)
+                    .await
+                    .expect("server");
+            });
+        }
+        None => {
+            let svc = grpc_server(LedgerService::new(conn));
+            tokio::spawn(async move {
+                Server::builder()
+                    .add_service(svc)
+                    .serve_with_incoming(incoming)
+                    .await
+                    .expect("server");
+            });
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn append_requires_bearer_token_when_enabled() {
+    let endpoint = start_server(Some("secret-token")).await;
+    let mut client = QuoteLedgerServiceClient::connect(endpoint)
+        .await
+        .expect("connect");
+
+    let cmd = QuoteCommand {
+        kind: Some(CmdKind::CreateQuote(CreateQuote {
+            currency_code: "USD".into(),
+            jurisdiction_id: "US-CA".into(),
+        })),
+    };
+    let (tx, rx) = tokio::sync::mpsc::channel::<AppendCommandRequest>(2);
+    tx.send(AppendCommandRequest {
+        client_command_id: "cc-1".into(),
+        quote_id: "q-auth-1".into(),
+        command: Some(cmd),
+    })
+    .await
+    .expect("send");
+    drop(tx);
+
+    let err = client
+        .append_commands(ReceiverStream::new(rx))
+        .await
+        .expect_err("missing auth should fail");
+    assert_eq!(err.code(), Code::Unauthenticated);
+}
+
+#[tokio::test]
+async fn subscribe_accepts_valid_bearer_token() {
+    let endpoint = start_server(Some("secret-token")).await;
+    let mut client = QuoteLedgerServiceClient::connect(endpoint)
+        .await
+        .expect("connect");
+
+    let mut req = Request::new(SubscribeQuoteRequest {
+        quote_id: "q-auth-2".into(),
+        after_seq: 0,
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        MetadataValue::from_static("Bearer secret-token"),
+    );
+
+    let response = client.subscribe_quote(req).await.expect("authorized");
+    let mut stream = response.into_inner();
+    let first = stream
+        .message()
+        .await
+        .expect("stream")
+        .expect("first frame");
+    assert!(first.kind.is_some());
+}
+
+#[tokio::test]
+async fn append_rejects_invalid_quote_id_characters() {
+    let endpoint = start_server(None).await;
+    let mut client = QuoteLedgerServiceClient::connect(endpoint)
+        .await
+        .expect("connect");
+
+    let cmd = QuoteCommand {
+        kind: Some(CmdKind::CreateQuote(CreateQuote {
+            currency_code: "USD".into(),
+            jurisdiction_id: "US-CA".into(),
+        })),
+    };
+    let (tx, rx) = tokio::sync::mpsc::channel::<AppendCommandRequest>(2);
+    tx.send(AppendCommandRequest {
+        client_command_id: "cc-1".into(),
+        quote_id: "bad id".into(),
+        command: Some(cmd),
+    })
+    .await
+    .expect("send");
+    drop(tx);
+
+    let err = client
+        .append_commands(ReceiverStream::new(rx))
+        .await
+        .expect_err("invalid quote_id");
+    assert_eq!(err.code(), Code::InvalidArgument);
+}


### PR DESCRIPTION
## Summary

Implements **v1.1-01** hardening:

- Adds optional bearer-token auth for ledger RPCs via .
- Tightens identifier validation for  and .
- Adds integration tests for unauthorized access and malformed identifiers.
- Updates README with auth configuration and grpcurl usage.

## Testing

- 
- 
running 9 tests
test domain::tests::finalize_requires_line ... ok
test domain::tests::add_line_then_totals_us_tax ... ok
test domain::tests::create_quote_rejects_blank_currency ... ok
test domain::tests::reduce_quote_created_from_empty ... ok
test domain::tests::create_quote_rejected_when_quote_exists ... ok
test domain::tests::create_quote_emits_single_event ... ok
test domain::tests::finalize_sets_flag ... ok
test domain::tests::reduce_rejects_second_quote_created ... ok
test domain::tests::replay_matches_folded_apply ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test append_then_subscribe_snapshot ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s


running 3 tests
test append_requires_bearer_token_when_enabled ... ok
test append_rejects_invalid_quote_id_characters ... ok
test subscribe_accepts_valid_bearer_token ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s


running 1 test
test subscribe_quote_empty_snapshot_smoke ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s


running 1 test
test pricing_finalize_snapshot ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.19s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
- 

Closes #11

Made with [Cursor](https://cursor.com)