### PR TITLE
feat: add reliability limits for append streams and gRPC server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ export QUOTE_LEDGER_DB="${TMPDIR:-/tmp}/quote_ledger.db"
 export METRICS_ADDR=127.0.0.1:9090
 # Optional: require `authorization: Bearer <token>` on ledger RPCs
 export QUOTE_LEDGER_AUTH_TOKEN=dev-local-token
+# Reliability defaults (optional overrides shown)
+export APPEND_IDLE_TIMEOUT_MS=10000
+export APPEND_MAX_COMMANDS=512
+export GRPC_CONCURRENCY_LIMIT=128
+export GRPC_KEEPALIVE_INTERVAL_MS=30000
+export GRPC_KEEPALIVE_TIMEOUT_MS=10000
 cargo run -- 127.0.0.1:50051
 ```
 
@@ -64,6 +70,17 @@ When `QUOTE_LEDGER_AUTH_TOKEN` is set, `AppendCommands` and `SubscribeQuote` req
 ### Shutdown
 
 On **Ctrl+C**, the gRPC server does **not** begin tonic shutdown until **in-flight `append_one` calls** drop to zero, or **30 seconds** elapse (whichever comes first). After that, `serve_with_shutdown` completes and the process exits.
+
+### Reliability limits
+
+- `APPEND_IDLE_TIMEOUT_MS` (default `10000`): if an `AppendCommands` stream is idle too long between frames, the call fails with `DEADLINE_EXCEEDED`.
+- `APPEND_MAX_COMMANDS` (default `512`): caps command count per `AppendCommands` stream; overflow fails with `RESOURCE_EXHAUSTED`.
+- `GRPC_CONCURRENCY_LIMIT` (default `128`): max concurrent RPCs per connection.
+- `GRPC_KEEPALIVE_INTERVAL_MS` / `GRPC_KEEPALIVE_TIMEOUT_MS` (defaults `30000` / `10000`): HTTP/2 keepalive policy.
+
+### Retry semantics
+
+`AppendCommands` is safe to retry for transient transport failures when each command keeps the same `(quote_id, client_command_id)` pair. The service deduplicates by that idempotency key and returns the already committed events.
 
 ## CI
 

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use metrics::{counter, gauge, histogram};
 use tokio::sync::mpsc;
@@ -27,6 +27,8 @@ use crate::v1::{
 };
 
 const MAX_ID_LEN: usize = 128;
+const DEFAULT_APPEND_IDLE_TIMEOUT_MS: u64 = 10_000;
+const DEFAULT_APPEND_MAX_COMMANDS: usize = 512;
 
 fn validate_identifier(field: &'static str, value: &str) -> Result<(), Status> {
     if value.trim().is_empty() {
@@ -87,6 +89,21 @@ impl Drop for AppendOneLatency {
     fn drop(&mut self) {
         histogram!("quote_ledger_append_one_duration_seconds")
             .record(self.0.elapsed().as_secs_f64());
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ReliabilityLimits {
+    pub append_idle_timeout: Duration,
+    pub append_max_commands: usize,
+}
+
+impl Default for ReliabilityLimits {
+    fn default() -> Self {
+        Self {
+            append_idle_timeout: Duration::from_millis(DEFAULT_APPEND_IDLE_TIMEOUT_MS),
+            append_max_commands: DEFAULT_APPEND_MAX_COMMANDS,
+        }
     }
 }
 
@@ -186,12 +203,18 @@ impl LedgerInner {
 
 pub struct LedgerService {
     pub(crate) inner: Arc<LedgerInner>,
+    reliability: ReliabilityLimits,
 }
 
 impl LedgerService {
     pub fn new(conn: rusqlite::Connection) -> Self {
+        Self::with_reliability(conn, ReliabilityLimits::default())
+    }
+
+    pub fn with_reliability(conn: rusqlite::Connection, reliability: ReliabilityLimits) -> Self {
         Self {
             inner: Arc::new(LedgerInner::new(conn)),
+            reliability,
         }
     }
 
@@ -215,13 +238,36 @@ impl QuoteLedgerService for LedgerService {
         let mut quote_id: Option<String> = None;
         let mut last_committed_seq: u64 = 0;
         let mut all_committed: Vec<StoredEvent> = Vec::new();
+        let mut command_count: usize = 0;
 
         loop {
-            let msg = match stream.message().await {
-                Ok(Some(m)) => m,
-                Ok(None) => break,
-                Err(e) => return Err(e),
+            let msg = match tokio::time::timeout(
+                self.reliability.append_idle_timeout,
+                stream.message(),
+            )
+            .await
+            {
+                Ok(Ok(Some(m))) => m,
+                Ok(Ok(None)) => break,
+                Ok(Err(e)) => return Err(e),
+                Err(_) => {
+                    counter!("quote_ledger_append_commands_streams_total", "result" => "timeout")
+                        .increment(1);
+                    return Err(Status::deadline_exceeded(
+                        "append_commands stream idle timeout",
+                    ));
+                }
             };
+
+            command_count += 1;
+            if command_count > self.reliability.append_max_commands {
+                counter!("quote_ledger_append_commands_streams_total", "result" => "too_many")
+                    .increment(1);
+                return Err(Status::resource_exhausted(format!(
+                    "append_commands stream exceeds max {} commands",
+                    self.reliability.append_max_commands
+                )));
+            }
 
             validate_identifier("client_command_id", &msg.client_command_id)?;
             validate_identifier("quote_id", &msg.quote_id)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod store;
 
 pub use auth::AuthInterceptor;
 pub use error::StoreError;
-pub use ledger::{grpc_server, LedgerService};
+pub use ledger::{grpc_server, LedgerService, ReliabilityLimits};
 
 /// gRPC reflection (`grpcurl` / Postman) — generated in `build.rs`.
 pub const FILE_DESCRIPTOR_SET: &[u8] =

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,25 @@ use tonic::transport::Server;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 
 use quote_ledger::v1::quote_ledger_service_server::QuoteLedgerServiceServer;
-use quote_ledger::{sqlite, AuthInterceptor, LedgerService, FILE_DESCRIPTOR_SET};
+use quote_ledger::{
+    sqlite, AuthInterceptor, LedgerService, ReliabilityLimits, FILE_DESCRIPTOR_SET,
+};
+
+fn env_u64(name: &str, default: u64) -> Result<u64, String> {
+    match std::env::var(name) {
+        Ok(v) => v.parse::<u64>().map_err(|e| format!("{name}: {e}")),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(std::env::VarError::NotUnicode(_)) => Err(format!("{name}: must be valid UTF-8")),
+    }
+}
+
+fn env_usize(name: &str, default: usize) -> Result<usize, String> {
+    match std::env::var(name) {
+        Ok(v) => v.parse::<usize>().map_err(|e| format!("{name}: {e}")),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(std::env::VarError::NotUnicode(_)) => Err(format!("{name}: must be valid UTF-8")),
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -56,7 +74,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let auth = AuthInterceptor::from_env_var("QUOTE_LEDGER_AUTH_TOKEN")
         .map_err(|e| format!("QUOTE_LEDGER_AUTH_TOKEN: {e}"))?;
 
-    let ledger_service = LedgerService::new(conn);
+    let append_idle_timeout_ms = env_u64("APPEND_IDLE_TIMEOUT_MS", 10_000)?;
+    let append_max_commands = env_usize("APPEND_MAX_COMMANDS", 512)?;
+    let grpc_concurrency_limit = env_u64("GRPC_CONCURRENCY_LIMIT", 128)? as usize;
+    let grpc_keepalive_interval_ms = env_u64("GRPC_KEEPALIVE_INTERVAL_MS", 30_000)?;
+    let grpc_keepalive_timeout_ms = env_u64("GRPC_KEEPALIVE_TIMEOUT_MS", 10_000)?;
+
+    let reliability = ReliabilityLimits {
+        append_idle_timeout: Duration::from_millis(append_idle_timeout_ms),
+        append_max_commands,
+    };
+
+    tracing::info!(
+        append_idle_timeout_ms,
+        append_max_commands,
+        grpc_concurrency_limit,
+        grpc_keepalive_interval_ms,
+        grpc_keepalive_timeout_ms,
+        "reliability limits configured"
+    );
+
+    let ledger_service = LedgerService::with_reliability(conn, reliability);
     let in_flight = ledger_service.in_flight_counter();
     let ledger = QuoteLedgerServiceServer::with_interceptor(ledger_service, auth);
 
@@ -67,6 +105,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     tracing::info!(%addr, "quote_ledger listening (reflection enabled for grpcurl)");
 
     Server::builder()
+        .concurrency_limit_per_connection(grpc_concurrency_limit)
+        .http2_keepalive_interval(Some(Duration::from_millis(grpc_keepalive_interval_ms)))
+        .http2_keepalive_timeout(Some(Duration::from_millis(grpc_keepalive_timeout_ms)))
         .add_service(reflection)
         .add_service(ledger)
         .serve_with_shutdown(addr, shutdown_signal(in_flight))

--- a/tests/reliability_limits.rs
+++ b/tests/reliability_limits.rs
@@ -1,0 +1,95 @@
+use std::time::Duration;
+
+use quote_ledger::v1::quote_command::Kind as CmdKind;
+use quote_ledger::v1::quote_ledger_service_client::QuoteLedgerServiceClient;
+use quote_ledger::v1::quote_ledger_service_server::QuoteLedgerServiceServer;
+use quote_ledger::v1::{AppendCommandRequest, CreateQuote, QuoteCommand};
+use quote_ledger::{sqlite, LedgerService, ReliabilityLimits};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server;
+use tonic::Code;
+
+async fn start_server(limits: ReliabilityLimits) -> String {
+    let dir = Box::leak(Box::new(tempfile::tempdir().expect("tempdir")));
+    let db = dir.path().join("reliability.db");
+    let conn = sqlite::open_and_migrate(db.to_str().expect("utf8 path")).expect("migrate");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let incoming = TcpListenerStream::new(listener);
+    let svc = QuoteLedgerServiceServer::new(LedgerService::with_reliability(conn, limits));
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(incoming)
+            .await
+            .expect("server");
+    });
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn append_stream_times_out_when_idle() {
+    let endpoint = start_server(ReliabilityLimits {
+        append_idle_timeout: Duration::from_millis(150),
+        append_max_commands: 8,
+    })
+    .await;
+    let mut client = QuoteLedgerServiceClient::connect(endpoint)
+        .await
+        .expect("connect");
+
+    let (_tx, rx) = tokio::sync::mpsc::channel::<AppendCommandRequest>(1);
+    let err = client
+        .append_commands(ReceiverStream::new(rx))
+        .await
+        .expect_err("idle stream should timeout");
+    assert_eq!(err.code(), Code::DeadlineExceeded);
+}
+
+#[tokio::test]
+async fn append_stream_rejects_too_many_commands() {
+    let endpoint = start_server(ReliabilityLimits {
+        append_idle_timeout: Duration::from_secs(5),
+        append_max_commands: 1,
+    })
+    .await;
+    let mut client = QuoteLedgerServiceClient::connect(endpoint)
+        .await
+        .expect("connect");
+
+    let cmd = QuoteCommand {
+        kind: Some(CmdKind::CreateQuote(CreateQuote {
+            currency_code: "USD".into(),
+            jurisdiction_id: "US-CA".into(),
+        })),
+    };
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<AppendCommandRequest>(4);
+    tx.send(AppendCommandRequest {
+        client_command_id: "cc-1".into(),
+        quote_id: "q-reliability-1".into(),
+        command: Some(cmd.clone()),
+    })
+    .await
+    .expect("send first");
+    tx.send(AppendCommandRequest {
+        client_command_id: "cc-2".into(),
+        quote_id: "q-reliability-1".into(),
+        command: Some(cmd),
+    })
+    .await
+    .expect("send second");
+    drop(tx);
+
+    let err = client
+        .append_commands(ReceiverStream::new(rx))
+        .await
+        .expect_err("too many commands should fail");
+    assert_eq!(err.code(), Code::ResourceExhausted);
+}


### PR DESCRIPTION
## Summary

Implements **v1.1-02** reliability controls:

- `AppendCommands` now enforces idle timeout and max commands per stream.
- Configurable gRPC keepalive and per-connection concurrency defaults in `main`.
- README documents reliability env vars and idempotent retry semantics.
- Adds integration tests for timeout and command-cap failure paths.

## Testing

- `cargo fmt --all`
- `cargo test --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`

Closes #12

Made with [Cursor](https://cursor.com)