### PR TITLE
docs: add ops runbook and sqlite backup/restore scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Configure branch protection to require the first four checks before merging to `
 - **Gaps:** no property/fuzz tests yet; no sustained long-run soak benchmark yet; **no enforced line-coverage floor** in CI (the `coverage` job reports numbers only).
 - **Local:** `cargo install cargo-llvm-cov` then `cargo llvm-cov test --workspace --all-features --html` for an HTML report.
 
+## Ops runbook (v1.1)
+
+- Runbook: `docs/ops-runbook.md`
+- Backup script: `scripts/backup_sqlite.sh <db_path> <backup_path>`
+- Restore script: `scripts/restore_sqlite.sh <backup_path> <db_path>`
+
 ## grpcurl (reflection)
 
 The server registers **gRPC reflection** (descriptor set from `build.rs`). With `grpcurl`:

--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -1,0 +1,69 @@
+# quote-ledger ops runbook (v1.1)
+
+This runbook covers baseline operations for the current single-process SQLite deployment.
+
+## 1) SLO indicators
+
+Use these indicators from `/metrics`:
+
+- **Append latency SLI**: `quote_ledger_append_one_duration_seconds`
+  - target suggestion: p95 < 250ms over 10m windows.
+- **Append stream outcome health**: `quote_ledger_append_commands_streams_total{result=*}`
+  - watch non-`ok` ratios (`invalid`, `timeout`, `too_many`).
+- **In-flight pressure**: `quote_ledger_in_flight_appends`
+  - sustained growth indicates writer pressure or downstream lock contention.
+- **Subscribe load trend**: `quote_ledger_subscribe_streams_total`
+  - useful for traffic-shift/context during incidents.
+
+## 2) Alert suggestions
+
+- **High append latency**: p95 append duration above threshold for >10m.
+- **Append error ratio spike**: (`invalid` + `timeout` + `too_many`) / total append streams > 5% for >5m.
+- **In-flight saturation**: in-flight appends > 0 and rising steadily for >5m.
+- **Instance down**: scrape target missing.
+
+## 3) Incident triage checklist
+
+1. Confirm process healthy and endpoints responsive:
+   - gRPC on service port
+   - `/metrics` on `METRICS_ADDR`
+2. Check recent error ratio and latency:
+   - `quote_ledger_append_commands_streams_total`
+   - `quote_ledger_append_one_duration_seconds`
+3. Check DB path and disk space (`QUOTE_LEDGER_DB`, free space).
+4. If shutdown/restart is needed:
+   - send SIGINT (`Ctrl+C`) and wait for bounded append drain logs.
+5. If data integrity is in question:
+   - take immediate backup (below) before any restore attempt.
+
+## 4) Backup and restore
+
+Scripts:
+
+- `scripts/backup_sqlite.sh <db_path> <backup_path>`
+- `scripts/restore_sqlite.sh <backup_path> <db_path>`
+
+### Backup example
+
+```bash
+scripts/backup_sqlite.sh /var/lib/quote-ledger/quote_ledger.db /var/backups/quote_ledger-$(date +%F-%H%M%S).db
+```
+
+### Restore example
+
+```bash
+# stop service first
+scripts/restore_sqlite.sh /var/backups/quote_ledger-2026-04-22-120000.db /var/lib/quote-ledger/quote_ledger.db
+```
+
+Restore behavior:
+
+- existing DB is moved to `<db_path>.pre-restore.<epoch>`
+- restore writes via sqlite backup API to a temp file then atomically renames
+
+## 5) Post-restore validation
+
+1. Start service with the restored DB.
+2. Run `grpcurl list` and `describe` checks.
+3. Execute a small append+subscribe smoke test.
+4. Confirm `/metrics` is exposed and append stream outcomes remain stable.

--- a/scripts/backup_sqlite.sh
+++ b/scripts/backup_sqlite.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Backup quote-ledger SQLite DB using sqlite's online backup API.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/backup_sqlite.sh <db_path> <backup_path>
+
+Example:
+  scripts/backup_sqlite.sh /var/lib/quote-ledger/quote_ledger.db /backups/quote_ledger-$(date +%F-%H%M%S).db
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+DB_PATH="${1:-}"
+BACKUP_PATH="${2:-}"
+
+if [[ -z "$DB_PATH" || -z "$BACKUP_PATH" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! -f "$DB_PATH" ]]; then
+  echo "error: db file does not exist: $DB_PATH" >&2
+  exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "error: sqlite3 CLI is required" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$BACKUP_PATH")"
+tmp_path="${BACKUP_PATH}.tmp.$$"
+rm -f "$tmp_path"
+
+escaped_tmp=${tmp_path//\'/\'\'}
+sqlite3 "$DB_PATH" ".timeout 5000" ".backup '$escaped_tmp'"
+mv "$tmp_path" "$BACKUP_PATH"
+
+echo "backup created: $BACKUP_PATH"

--- a/scripts/restore_sqlite.sh
+++ b/scripts/restore_sqlite.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Restore quote-ledger SQLite DB from a backup file.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/restore_sqlite.sh <backup_path> <db_path>
+
+Notes:
+  - Stop quote-ledger before restore to avoid open-writer conflicts.
+  - Existing DB is moved to "<db_path>.pre-restore.<epoch>" before restore.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+BACKUP_PATH="${1:-}"
+DB_PATH="${2:-}"
+
+if [[ -z "$BACKUP_PATH" || -z "$DB_PATH" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! -f "$BACKUP_PATH" ]]; then
+  echo "error: backup file does not exist: $BACKUP_PATH" >&2
+  exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "error: sqlite3 CLI is required" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$DB_PATH")"
+
+if [[ -f "$DB_PATH" ]]; then
+  stamp="$(date +%s)"
+  prev="${DB_PATH}.pre-restore.${stamp}"
+  mv "$DB_PATH" "$prev"
+  [[ -f "${DB_PATH}-wal" ]] && mv "${DB_PATH}-wal" "${prev}-wal" || true
+  [[ -f "${DB_PATH}-shm" ]] && mv "${DB_PATH}-shm" "${prev}-shm" || true
+  echo "previous database moved to: $prev"
+fi
+
+tmp_path="${DB_PATH}.tmp.$$"
+rm -f "$tmp_path"
+
+escaped_tmp=${tmp_path//\'/\'\'}
+sqlite3 "$BACKUP_PATH" ".timeout 5000" ".backup '$escaped_tmp'"
+mv "$tmp_path" "$DB_PATH"
+
+echo "database restored to: $DB_PATH"


### PR DESCRIPTION
## Summary

Implements **v1.1-04** ops readiness:

- Adds `docs/ops-runbook.md` with:
  - SLO indicators tied to existing metrics
  - alert suggestions
  - incident triage checklist
  - backup/restore and post-restore validation steps
- Adds executable scripts:
  - `scripts/backup_sqlite.sh`
  - `scripts/restore_sqlite.sh`
- Updates README with runbook + backup/restore entry points.

## Validation

- Local backup/restore round-trip with temp sqlite db:
  - create table + rows
  - backup
  - restore
  - verify row count

## Testing

- `cargo fmt --all`
- `cargo test --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`

Closes #14

Made with [Cursor](https://cursor.com)