### PR TITLE
feat: v1.2 production hardening (epics G–M)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +164,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +259,20 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "dunce"
@@ -304,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,12 +393,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -375,9 +429,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -391,6 +447,29 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -433,7 +512,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -685,6 +775,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,12 +880,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -810,6 +924,29 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -891,6 +1028,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -1025,6 +1181,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,8 +1200,11 @@ name = "quote_ledger"
 version = "1.0.0"
 dependencies = [
  "axum",
+ "constant_time_eq",
+ "governor",
  "metrics",
  "metrics-exporter-prometheus",
+ "proptest",
  "prost",
  "protoc-bin-vendored",
  "rusqlite",
@@ -1073,8 +1238,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1084,7 +1259,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1097,10 +1282,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
@@ -1184,6 +1396,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1200,6 +1413,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1230,6 +1452,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1477,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1402,6 +1642,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,8 +1798,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -1596,7 +1847,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -1702,6 +1953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,6 +1993,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -1854,6 +2120,16 @@ name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,16 @@ axum = "0.7"
 metrics = "0.23"
 metrics-exporter-prometheus = "0.15"
 prost = "0.13"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "test-util"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
-tonic = { version = "0.12", features = ["transport"] }
+tonic = { version = "0.12", features = ["transport", "tls"] }
 tonic-reflection = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 thiserror = "1"
+constant_time_eq = "0.3"
+governor = "0.10"
 
 [build-dependencies]
 tonic-build = "0.12"
@@ -26,3 +28,4 @@ protoc-bin-vendored = "3"
 
 [dev-dependencies]
 tempfile = "3"
+proptest = "1"

--- a/README.md
+++ b/README.md
@@ -39,10 +39,21 @@ Run the gRPC server (creates/applies SQLite migrations):
 
 ```bash
 export QUOTE_LEDGER_DB="${TMPDIR:-/tmp}/quote_ledger.db"
+# Optional: explicit gRPC listen addr (avoids argv parsing in tests / containers)
+export GRPC_LISTEN_ADDR=127.0.0.1:50051
 # Optional: Prometheus scrape endpoint (default 127.0.0.1:9090)
 export METRICS_ADDR=127.0.0.1:9090
 # Optional: require `authorization: Bearer <token>` on ledger RPCs
 export QUOTE_LEDGER_AUTH_TOKEN=dev-local-token
+# Optional: disable gRPC reflection in locked-down environments (default: enabled)
+export QUOTE_LEDGER_REFLECTION=false
+# Optional: mTLS / TLS for gRPC (both must be set)
+# export GRPC_TLS_CERT=/path/to/cert.pem
+# export GRPC_TLS_KEY=/path/to/key.pem
+# Optional: fail startup on unknown QUOTE_LEDGER_* / APPEND_* / GRPC_* env keys (typos)
+# export STRICT_CONFIG=true
+# Optional: process-wide cap on accepted gRPC RPCs per second (all methods share one bucket)
+# export GRPC_RATE_LIMIT_RPS=500
 # Reliability defaults (optional overrides shown)
 export APPEND_IDLE_TIMEOUT_MS=10000
 export APPEND_MAX_COMMANDS=512
@@ -82,6 +93,19 @@ On **Ctrl+C**, the gRPC server does **not** begin tonic shutdown until **in-flig
 
 `AppendCommands` is safe to retry for transient transport failures when each command keeps the same `(quote_id, client_command_id)` pair. The service deduplicates by that idempotency key and returns the already committed events.
 
+Reusing the same `(quote_id, client_command_id)` with a **different** command payload returns `FAILED_PRECONDITION` (idempotency conflict).
+
+### SubscribeQuote semantics
+
+- **`after_seq`**: exclusive lower bound; `0` means “from the beginning”. If `after_seq` is greater than the current head, the call fails with `INVALID_ARGUMENT`.
+- **Delivery**: the stream first may emit a **tail** of historical events (if needed), then a **snapshot** (`QuoteView` + `last_seq`), then **tails** for live commits. On persistent read failures, the server retries bounded times; if reads still fail, the stream ends with an error status — **reconnect with the last processed `seq`** (from tail or snapshot) as `after_seq`.
+- **Metrics**: see `docs/ops-runbook.md` for subscribe DB retry / terminal error counters.
+
+## API versioning & client migrations
+
+- Policy: `docs/api-versioning.md`
+- Checklist: `docs/client-migration-checklist.md`
+
 ## CI
 
 Pull requests run **fmt**, **clippy**, **test** (includes gRPC smoke), **release-build-smoke**, and a **`coverage`** job that prints an **llvm-cov** summary (line/region totals — informational unless you add a threshold).
@@ -97,6 +121,8 @@ Configure branch protection to require the first four checks before merging to `
 ## Ops runbook (v1.1)
 
 - Runbook: `docs/ops-runbook.md`
+- SQLite migrations (operator notes): `docs/database-migrations.md`
+- Example Prometheus alerts: `docs/prometheus/alerts.example.yml`
 - Backup script: `scripts/backup_sqlite.sh <db_path> <backup_path>`
 - Restore script: `scripts/restore_sqlite.sh <backup_path> <db_path>`
 

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,22 @@
+# API & protobuf versioning (quote_ledger)
+
+## Package naming
+
+Breaking wire or behavioral changes should introduce a new `package` (for example `quote_ledger.v2`) **or** a clearly documented compatibility window where old clients continue to work.
+
+## Field evolution
+
+- Prefer **adding** fields and reserving numbers; avoid reusing field numbers.
+- Mark deprecated fields in `.proto` comments and keep server behavior tolerant until clients migrate.
+- For removals or semantic changes, bump the package version or gate behavior behind explicit configuration.
+
+## Server rollout
+
+1. Deploy a server build that **accepts both** old and new clients (if dual-read is required).
+2. Migrate clients to the new stubs.
+3. Remove compatibility paths after the agreed sunset date.
+
+## Compatibility testing
+
+- Keep at least one integration test per major client contract (append, subscribe, pricing).
+- Run `grpcurl` against both old and new descriptors during migration.

--- a/docs/client-migration-checklist.md
+++ b/docs/client-migration-checklist.md
@@ -1,0 +1,25 @@
+# Client migration checklist (gRPC / protobuf)
+
+Use this when bumping `quote_ledger` server versions or regenerating stubs.
+
+## Before upgrading
+
+- [ ] Read release notes / milestone issues for breaking RPC or semantics changes.
+- [ ] Confirm `SubscribeQuote` contract (reconnect, `after_seq`, error handling) matches your client.
+
+## Stub upgrade
+
+- [ ] Regenerate protobuf stubs for your language (Rust `tonic-build`, Go `protoc-gen-go-grpc`, etc.).
+- [ ] Re-run compile on the client monorepo.
+- [ ] Run client integration tests against a pinned server version in CI.
+
+## Runtime configuration
+
+- [ ] If auth is enabled (`QUOTE_LEDGER_AUTH_TOKEN`), thread the `authorization: Bearer …` metadata on all ledger RPCs.
+- [ ] If TLS is enabled (`GRPC_TLS_CERT` / `GRPC_TLS_KEY` on server), point clients at `https` / TLS roots as appropriate.
+
+## Rollout
+
+- [ ] Canary a small slice of traffic against the new server build.
+- [ ] Watch append latency and append stream outcome metrics during the canary.
+- [ ] Roll forward or roll back with a documented decision.

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,0 +1,15 @@
+# SQLite schema migrations
+
+The service applies SQL migrations from the `migrations/` directory on startup (`sqlite::open_and_migrate`). Migrations are **ordered by filename** and run in a single SQLite transaction per startup batch.
+
+## Operator expectations
+
+- **Backup before upgrades**: take a filesystem copy of `QUOTE_LEDGER_DB` (see `scripts/backup_sqlite.sh`) before deploying a binary that adds migrations.
+- **One writer**: only one `quote_ledger` process should open the database file at a time for the current single-node design.
+- **WAL and pragmas**: after migrations, the connection enables WAL, busy timeout, and related durability settings (`src/sqlite.rs`). Changing these at runtime outside the binary is unsupported.
+
+## Adding a migration
+
+1. Add a new file `migrations/NNN_description.sql` with a monotonically increasing `NNN` prefix.
+2. Prefer additive changes (new tables/columns/indexes); avoid rewriting large tables in-place during migration.
+3. Document any required one-off data backfill in the PR that introduces the migration.

--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -14,6 +14,10 @@ Use these indicators from `/metrics`:
   - sustained growth indicates writer pressure or downstream lock contention.
 - **Subscribe load trend**: `quote_ledger_subscribe_streams_total`
   - useful for traffic-shift/context during incidents.
+- **Subscribe DB resilience**: `quote_ledger_subscribe_db_retries_total`, `quote_ledger_subscribe_db_load_failures_total`, `quote_ledger_subscribe_stream_terminal_errors_total`
+  - retries indicate transient SQLite pressure; terminal errors mean clients should reconnect and operators should investigate storage health.
+- **Global gRPC rate limiting** (when `GRPC_RATE_LIMIT_RPS` is set): `quote_ledger_grpc_rate_limited_total`
+  - sustained growth means legitimate traffic is competing for a low cap, or an abusive client; tune `GRPC_RATE_LIMIT_RPS` or add edge rate limiting.
 
 ## 2) Alert suggestions
 

--- a/docs/prometheus/alerts.example.yml
+++ b/docs/prometheus/alerts.example.yml
@@ -1,0 +1,44 @@
+# Example Prometheus alerting rules for quote-ledger (v1.2).
+# Copy into your Prometheus `rule_files` after validating thresholds for your environment.
+
+groups:
+  - name: quote-ledger
+    rules:
+      - alert: QuoteLedgerAppendLatencyHigh
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(quote_ledger_append_one_duration_seconds_bucket[10m])) by (le)
+          ) > 0.25
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "quote-ledger append p95 latency above 250ms"
+
+      - alert: QuoteLedgerAppendStreamErrors
+        expr: |
+          sum(rate(quote_ledger_append_commands_streams_total{result!="ok"}[5m]))
+            /
+          sum(rate(quote_ledger_append_commands_streams_total[5m]))
+          > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "quote-ledger append_commands non-ok ratio > 5%"
+
+      - alert: QuoteLedgerSubscribeDbTerminal
+        expr: sum(rate(quote_ledger_subscribe_stream_terminal_errors_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "quote-ledger subscribe DB terminal errors observed"
+
+      - alert: QuoteLedgerGrpcRateLimited
+        expr: sum(rate(quote_ledger_grpc_rate_limited_total[5m])) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "quote-ledger global gRPC rate limit is rejecting traffic (tune GRPC_RATE_LIMIT_RPS or add edge limiting)"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -33,6 +33,11 @@ impl AuthInterceptor {
         }
     }
 
+    /// Validate auth metadata (used by [`crate::grpc_interceptor::LedgerGrpcInterceptor`]).
+    pub fn intercept(&self, request: Request<()>) -> Result<Request<()>, Status> {
+        self.check_request(request)
+    }
+
     fn check_request(&self, request: Request<()>) -> Result<Request<()>, Status> {
         let Some(expected) = self.expected_token.as_ref() else {
             return Ok(request);
@@ -56,7 +61,9 @@ impl AuthInterceptor {
                 "authorization scheme must be Bearer",
             ));
         }
-        if token != expected {
+        if expected.len() != token.len()
+            || !constant_time_eq::constant_time_eq(expected.as_bytes(), token.as_bytes())
+        {
             return Err(Status::unauthenticated("invalid bearer token"));
         }
 
@@ -66,6 +73,6 @@ impl AuthInterceptor {
 
 impl Interceptor for AuthInterceptor {
     fn call(&mut self, request: Request<()>) -> Result<Request<()>, Status> {
-        self.check_request(request)
+        self.intercept(request)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,210 @@
+//! Centralized service configuration from environment variables.
+
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::num::NonZeroU32;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::ledger::ReliabilityLimits;
+
+const KNOWN_ENV_KEYS: &[&str] = &[
+    "APPEND_IDLE_TIMEOUT_MS",
+    "APPEND_MAX_COMMANDS",
+    "GRPC_CONCURRENCY_LIMIT",
+    "GRPC_KEEPALIVE_INTERVAL_MS",
+    "GRPC_KEEPALIVE_TIMEOUT_MS",
+    "GRPC_LISTEN_ADDR",
+    "GRPC_RATE_LIMIT_RPS",
+    "GRPC_TLS_CERT",
+    "GRPC_TLS_KEY",
+    "METRICS_ADDR",
+    "QUOTE_LEDGER_AUTH_TOKEN",
+    "QUOTE_LEDGER_DB",
+    "QUOTE_LEDGER_REFLECTION",
+    "STRICT_CONFIG",
+];
+
+fn env_u64(name: &str, default: u64) -> Result<u64, String> {
+    match std::env::var(name) {
+        Ok(v) => v.parse::<u64>().map_err(|e| format!("{name}: {e}")),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(std::env::VarError::NotUnicode(_)) => Err(format!("{name}: must be valid UTF-8")),
+    }
+}
+
+fn env_usize(name: &str, default: usize) -> Result<usize, String> {
+    match std::env::var(name) {
+        Ok(v) => v.parse::<usize>().map_err(|e| format!("{name}: {e}")),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(std::env::VarError::NotUnicode(_)) => Err(format!("{name}: must be valid UTF-8")),
+    }
+}
+
+fn env_bool(name: &str, default: bool) -> Result<bool, String> {
+    match std::env::var(name) {
+        Ok(v) => match v.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Ok(true),
+            "0" | "false" | "no" | "off" => Ok(false),
+            other => Err(format!("{name}: expected true/false, got {other:?}")),
+        },
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(std::env::VarError::NotUnicode(_)) => Err(format!("{name}: must be valid UTF-8")),
+    }
+}
+
+fn env_opt_nonzero_u32(name: &str) -> Result<Option<NonZeroU32>, String> {
+    match std::env::var(name) {
+        Ok(v) => {
+            let t = v.trim();
+            if t.is_empty() {
+                return Err(format!("{name} must not be empty when set"));
+            }
+            let n: u32 = t
+                .parse()
+                .map_err(|e| format!("{name}: invalid integer: {e}"))?;
+            let nz = NonZeroU32::new(n).ok_or_else(|| format!("{name} must be >= 1"))?;
+            Ok(Some(nz))
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(format!("{name}: must be valid UTF-8")),
+    }
+}
+
+fn env_opt_path(name: &str) -> Result<Option<PathBuf>, String> {
+    match std::env::var(name) {
+        Ok(v) => {
+            let t = v.trim();
+            if t.is_empty() {
+                return Err(format!("{name} must not be empty when set"));
+            }
+            Ok(Some(PathBuf::from(t)))
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(format!("{name}: must be valid UTF-8")),
+    }
+}
+
+fn validate_strict_unknown() -> Result<(), String> {
+    if !env_bool("STRICT_CONFIG", false)? {
+        return Ok(());
+    }
+    let known: HashSet<&'static str> = KNOWN_ENV_KEYS.iter().copied().collect();
+    for (k, _) in std::env::vars() {
+        let is_quote_ledger = k.starts_with("QUOTE_LEDGER_");
+        let is_append = k.starts_with("APPEND_");
+        let is_grpc = k.starts_with("GRPC_");
+        if !(is_quote_ledger || is_append || is_grpc) {
+            continue;
+        }
+        if known.contains(k.as_str()) {
+            continue;
+        }
+        return Err(format!(
+            "STRICT_CONFIG: unknown environment variable {k:?} (typo?)"
+        ));
+    }
+    Ok(())
+}
+
+/// Fully validated runtime configuration for the `quote_ledger` binary.
+#[derive(Debug, Clone)]
+pub struct ServiceConfig {
+    pub grpc_listen: SocketAddr,
+    pub metrics_listen: SocketAddr,
+    pub db_path: String,
+    pub reliability: ReliabilityLimits,
+    pub grpc_concurrency_limit: usize,
+    pub grpc_keepalive_interval: Duration,
+    pub grpc_keepalive_timeout: Duration,
+    pub reflection_enabled: bool,
+    pub grpc_tls_cert: Option<PathBuf>,
+    pub grpc_tls_key: Option<PathBuf>,
+    /// When set, all gRPC RPCs share a single process-wide token bucket (`governor`).
+    pub grpc_rate_limit_rps: Option<NonZeroU32>,
+}
+
+impl ServiceConfig {
+    /// Load from process environment and `argv` (first positional = gRPC listen addr).
+    pub fn from_env_and_args() -> Result<Self, String> {
+        validate_strict_unknown()?;
+
+        let grpc_listen = match std::env::var("GRPC_LISTEN_ADDR") {
+            Ok(v) => v.parse().map_err(|e| format!("GRPC_LISTEN_ADDR: {e}"))?,
+            Err(std::env::VarError::NotPresent) => std::env::args()
+                .nth(1)
+                .unwrap_or_else(|| "127.0.0.1:50051".to_string())
+                .parse()
+                .map_err(|e| format!("grpc listen address (argv[1] or default): {e}"))?,
+            Err(std::env::VarError::NotUnicode(_)) => {
+                return Err("GRPC_LISTEN_ADDR: must be valid UTF-8".into());
+            }
+        };
+
+        let metrics_listen: SocketAddr = std::env::var("METRICS_ADDR")
+            .unwrap_or_else(|_| "127.0.0.1:9090".into())
+            .parse()
+            .map_err(|e| format!("METRICS_ADDR: {e}"))?;
+
+        let db_path = std::env::var("QUOTE_LEDGER_DB").unwrap_or_else(|_| "quote_ledger.db".into());
+
+        let append_idle_timeout_ms = env_u64("APPEND_IDLE_TIMEOUT_MS", 10_000)?;
+        let append_max_commands = env_usize("APPEND_MAX_COMMANDS", 512)?;
+        if append_max_commands < 1 {
+            return Err("APPEND_MAX_COMMANDS must be >= 1".into());
+        }
+        if !(1..=3_600_000).contains(&append_idle_timeout_ms) {
+            return Err("APPEND_IDLE_TIMEOUT_MS must be between 1 and 3600000".into());
+        }
+
+        let grpc_concurrency_limit = env_usize("GRPC_CONCURRENCY_LIMIT", 128)?;
+        if grpc_concurrency_limit < 1 {
+            return Err("GRPC_CONCURRENCY_LIMIT must be >= 1".into());
+        }
+
+        let grpc_keepalive_interval_ms = env_u64("GRPC_KEEPALIVE_INTERVAL_MS", 30_000)?;
+        let grpc_keepalive_timeout_ms = env_u64("GRPC_KEEPALIVE_TIMEOUT_MS", 10_000)?;
+        if grpc_keepalive_interval_ms < 1 {
+            return Err("GRPC_KEEPALIVE_INTERVAL_MS must be >= 1".into());
+        }
+        if grpc_keepalive_timeout_ms < 1 {
+            return Err("GRPC_KEEPALIVE_TIMEOUT_MS must be >= 1".into());
+        }
+        if grpc_keepalive_timeout_ms >= grpc_keepalive_interval_ms {
+            return Err(
+                "GRPC_KEEPALIVE_TIMEOUT_MS must be less than GRPC_KEEPALIVE_INTERVAL_MS".into(),
+            );
+        }
+
+        let reflection_enabled = env_bool("QUOTE_LEDGER_REFLECTION", true)?;
+
+        let cert = env_opt_path("GRPC_TLS_CERT")?;
+        let key = env_opt_path("GRPC_TLS_KEY")?;
+        let (grpc_tls_cert, grpc_tls_key) = match (&cert, &key) {
+            (Some(c), Some(k)) => (Some(c.clone()), Some(k.clone())),
+            (None, None) => (None, None),
+            _ => {
+                return Err("GRPC_TLS_CERT and GRPC_TLS_KEY must both be set or both unset".into());
+            }
+        };
+
+        let grpc_rate_limit_rps = env_opt_nonzero_u32("GRPC_RATE_LIMIT_RPS")?;
+
+        Ok(Self {
+            grpc_listen,
+            metrics_listen,
+            db_path,
+            reliability: ReliabilityLimits {
+                append_idle_timeout: Duration::from_millis(append_idle_timeout_ms),
+                append_max_commands,
+            },
+            grpc_concurrency_limit,
+            grpc_keepalive_interval: Duration::from_millis(grpc_keepalive_interval_ms),
+            grpc_keepalive_timeout: Duration::from_millis(grpc_keepalive_timeout_ms),
+            reflection_enabled,
+            grpc_tls_cert,
+            grpc_tls_key,
+            grpc_rate_limit_rps,
+        })
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -174,4 +174,34 @@ mod tests {
         .unwrap_err();
         assert_eq!(err, DomainError::QuoteAlreadyFinalized);
     }
+
+    use proptest::prelude::*;
+
+    #[test]
+    fn proptest_create_quote_emits_single_created_event() {
+        proptest!(|(currency in "[A-Z]{3}", jur in "US|US-CA|DE|JP")| {
+            let cmd = DomainCommand::CreateQuote {
+                currency_code: currency.clone(),
+                jurisdiction_id: jur.clone(),
+            };
+            let events = command_to_events(&QuoteState::default(), &cmd).map_err(|e| {
+                proptest::test_runner::TestCaseError::fail(format!("{e:?}"))
+            })?;
+            prop_assert_eq!(events.len(), 1);
+            let is_created = matches!(&events[0], DomainEvent::QuoteCreated { .. });
+            prop_assert!(is_created);
+            if let DomainEvent::QuoteCreated {
+                currency_code,
+                jurisdiction_id,
+            } = &events[0]
+            {
+                prop_assert_eq!(currency_code, &currency);
+                prop_assert_eq!(jurisdiction_id, &jur);
+            }
+            let s = reduce(&QuoteState::default(), &events[0]).map_err(|e| {
+                proptest::test_runner::TestCaseError::fail(format!("{e:?}"))
+            })?;
+            prop_assert!(s.is_created());
+        });
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,4 +16,12 @@ pub enum StoreError {
 
     #[error("corrupt stored payload: {0}")]
     Corrupt(String),
+
+    #[error(
+        "idempotency key reused with different command payload (quote_id={quote_id}, client_command_id={client_command_id})"
+    )]
+    IdempotencyConflict {
+        quote_id: String,
+        client_command_id: String,
+    },
 }

--- a/src/grpc_interceptor.rs
+++ b/src/grpc_interceptor.rs
@@ -1,0 +1,82 @@
+//! Composite gRPC interceptor: optional process-wide request rate limit, then auth.
+
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use governor::clock::DefaultClock;
+use governor::state::{InMemoryState, NotKeyed};
+use governor::{Quota, RateLimiter};
+use metrics::counter;
+use tonic::service::Interceptor;
+use tonic::{Request, Status};
+
+use crate::auth::AuthInterceptor;
+
+/// Process-wide limit on accepted **RPCs** (all methods share one token bucket).
+pub type GlobalRequestLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
+
+#[derive(Clone)]
+pub struct LedgerGrpcInterceptor {
+    auth: AuthInterceptor,
+    limiter: Option<Arc<GlobalRequestLimiter>>,
+}
+
+impl LedgerGrpcInterceptor {
+    pub fn new(auth: AuthInterceptor, requests_per_second: Option<NonZeroU32>) -> Self {
+        let limiter = requests_per_second
+            .map(|n| Arc::new(GlobalRequestLimiter::direct(Quota::per_second(n))));
+        Self { auth, limiter }
+    }
+}
+
+impl Interceptor for LedgerGrpcInterceptor {
+    fn call(&mut self, request: Request<()>) -> Result<Request<()>, Status> {
+        if let Some(lim) = &self.limiter {
+            if lim.check().is_err() {
+                counter!("quote_ledger_grpc_rate_limited_total").increment(1);
+                return Err(Status::resource_exhausted(
+                    "global gRPC request rate limit exceeded (set GRPC_RATE_LIMIT_RPS)",
+                ));
+            }
+        }
+        self.auth.intercept(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+    use std::time::Duration;
+
+    use governor::{Quota, RateLimiter};
+    use tonic::Request;
+
+    use super::*;
+
+    #[test]
+    fn burst_one_then_immediate_second_is_denied() {
+        let quota = Quota::with_period(Duration::from_secs(3600))
+            .expect("quota")
+            .allow_burst(NonZeroU32::new(1).unwrap());
+        let lim: Arc<GlobalRequestLimiter> = Arc::new(RateLimiter::direct(quota));
+        assert!(lim.check().is_ok());
+        assert!(lim.check().is_err());
+    }
+
+    #[test]
+    fn interceptor_returns_err_when_bucket_empty() {
+        let auth =
+            AuthInterceptor::from_env_var("QUOTE_LEDGER_AUTH_TOKEN_UNUSED_FOR_RATE_LIMIT_TEST")
+                .expect("env");
+        let quota = Quota::with_period(Duration::from_secs(3600))
+            .expect("quota")
+            .allow_burst(NonZeroU32::new(1).unwrap());
+        let lim: Arc<GlobalRequestLimiter> = Arc::new(RateLimiter::direct(quota));
+        let mut ix = LedgerGrpcInterceptor {
+            auth,
+            limiter: Some(lim),
+        };
+        assert!(ix.call(Request::new(())).is_ok());
+        assert!(ix.call(Request::new(())).is_err());
+    }
+}

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -16,8 +16,8 @@ use tracing::instrument;
 
 use crate::domain;
 use crate::mapping::{
-    domain_error_to_status, domain_event_to_proto, proto_command_to_domain, quote_state_to_view,
-    replay_stored_to_state, store_error_to_status,
+    domain_event_to_proto, proto_command_to_domain, quote_state_to_view, replay_stored_to_state,
+    store_error_to_status,
 };
 use crate::store;
 use crate::v1::quote_ledger_service_server::{QuoteLedgerService, QuoteLedgerServiceServer};
@@ -29,6 +29,50 @@ use crate::v1::{
 const MAX_ID_LEN: usize = 128;
 const DEFAULT_APPEND_IDLE_TIMEOUT_MS: u64 = 10_000;
 const DEFAULT_APPEND_MAX_COMMANDS: usize = 512;
+
+/// Bounded retries for SQLite reads on the subscribe pump. Transient failures must not skip seqs.
+const SUBSCRIBE_DB_MAX_ATTEMPTS: u32 = 8;
+const SUBSCRIBE_DB_BACKOFF_START_MS: u64 = 10;
+const SUBSCRIBE_DB_BACKOFF_CAP_MS: u64 = 500;
+
+async fn subscribe_load_between(
+    inner: &LedgerInner,
+    quote_id: &str,
+    after_exclusive: u64,
+    upto_inclusive: u64,
+) -> Result<Vec<StoredEvent>, Status> {
+    let mut backoff_ms = SUBSCRIBE_DB_BACKOFF_START_MS;
+    let mut last_err: Option<Status> = None;
+
+    for attempt in 0..SUBSCRIBE_DB_MAX_ATTEMPTS {
+        if attempt > 0 {
+            counter!("quote_ledger_subscribe_db_retries_total").increment(1);
+            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+            backoff_ms = (backoff_ms.saturating_mul(2)).min(SUBSCRIBE_DB_BACKOFF_CAP_MS);
+        }
+
+        match inner
+            .db({
+                let q = quote_id.to_string();
+                move |c| store::load_stored_events_between(c, &q, after_exclusive, upto_inclusive)
+            })
+            .await
+        {
+            Ok(events) => return Ok(events),
+            Err(e) => {
+                counter!("quote_ledger_subscribe_db_load_failures_total").increment(1);
+                last_err = Some(e);
+            }
+        }
+    }
+
+    counter!(
+        "quote_ledger_subscribe_stream_terminal_errors_total",
+        "cause" => "db_load_between"
+    )
+    .increment(1);
+    Err(last_err.unwrap_or_else(|| Status::internal("subscribe db load failed")))
+}
 
 fn validate_identifier(field: &'static str, value: &str) -> Result<(), Status> {
     if value.trim().is_empty() {
@@ -160,35 +204,42 @@ impl LedgerInner {
         let quote_id_owned = quote_id.to_string();
         let client_owned = client_command_id.to_string();
 
-        if let Some(committed) = self
-            .db({
-                let q = quote_id_owned.clone();
-                let c = client_owned.clone();
-                move |conn| store::try_load_idempotent_events(conn, &q, &c)
-            })
-            .await?
-        {
-            return Ok(committed);
-        }
-
         let domain_cmd = proto_command_to_domain(cmd)?;
 
-        let all = self
-            .db({
-                let q = quote_id_owned.clone();
-                move |c| store::load_stored_events(c, &q)
-            })
-            .await?;
-
-        let state = replay_stored_to_state(&all).map_err(store_error_to_status)?;
-        let events =
-            domain::command_to_events(&state, &domain_cmd).map_err(domain_error_to_status)?;
-        let proto_events: Vec<crate::v1::QuoteEvent> =
-            events.iter().map(domain_event_to_proto).collect();
-
         let committed = self
-            .db(move |c| {
-                store::append_command_events(c, &quote_id_owned, &client_owned, &proto_events)
+            .db({
+                let quote_id_owned = quote_id_owned.clone();
+                let client_owned = client_owned.clone();
+                let domain_cmd = domain_cmd.clone();
+                move |c| {
+                    if let Some((first_seq, _last_seq)) =
+                        store::idempotency_lookup(c, &quote_id_owned, &client_owned)?
+                    {
+                        let before = store::load_stored_events_between(
+                            c,
+                            &quote_id_owned,
+                            0,
+                            first_seq.saturating_sub(1),
+                        )?;
+                        let state_before = replay_stored_to_state(&before)?;
+                        let events = domain::command_to_events(&state_before, &domain_cmd)?;
+                        let proto_events: Vec<crate::v1::QuoteEvent> =
+                            events.iter().map(domain_event_to_proto).collect();
+                        return store::append_command_events(
+                            c,
+                            &quote_id_owned,
+                            &client_owned,
+                            &proto_events,
+                        );
+                    }
+
+                    let all = store::load_stored_events(c, &quote_id_owned)?;
+                    let state = replay_stored_to_state(&all)?;
+                    let events = domain::command_to_events(&state, &domain_cmd)?;
+                    let proto_events: Vec<crate::v1::QuoteEvent> =
+                        events.iter().map(domain_event_to_proto).collect();
+                    store::append_command_events(c, &quote_id_owned, &client_owned, &proto_events)
+                }
             })
             .await?;
 
@@ -317,6 +368,7 @@ impl QuoteLedgerService for LedgerService {
     type SubscribeQuoteStream =
         Pin<Box<dyn Stream<Item = Result<QuoteUpdate, Status>> + Send + 'static>>;
 
+    #[instrument(skip(self, request))]
     async fn subscribe_quote(
         &self,
         request: Request<SubscribeQuoteRequest>,
@@ -421,29 +473,30 @@ impl QuoteLedgerService for LedgerService {
 
             let head_now = *rx_watch.borrow();
             if head_now > watermark {
-                match inner2
-                    .db({
-                        let q = qid2.clone();
-                        move |c| store::load_stored_events_between(c, &q, watermark, head_now)
-                    })
-                    .await
-                {
-                    Ok(chunk) if !chunk.is_empty() => {
-                        let from = watermark;
-                        let to = chunk.last().map(|e| e.seq).unwrap_or(from);
-                        let tail = QuoteUpdate {
-                            kind: Some(quote_update::Kind::Tail(QuoteTail {
-                                from_seq_exclusive: from,
-                                to_seq_inclusive: to,
-                                events: chunk,
-                            })),
-                        };
-                        if !push_update(&tx, tail).await {
-                            return;
+                match subscribe_load_between(&inner2, &qid2, watermark, head_now).await {
+                    Ok(chunk) => {
+                        if chunk.is_empty() {
+                            watermark = head_now;
+                        } else {
+                            let from = watermark;
+                            let to = chunk.last().map(|e| e.seq).unwrap_or(from);
+                            let tail = QuoteUpdate {
+                                kind: Some(quote_update::Kind::Tail(QuoteTail {
+                                    from_seq_exclusive: from,
+                                    to_seq_inclusive: to,
+                                    events: chunk,
+                                })),
+                            };
+                            if !push_update(&tx, tail).await {
+                                return;
+                            }
+                            watermark = head_now;
                         }
-                        watermark = head_now;
                     }
-                    _ => watermark = head_now,
+                    Err(status) => {
+                        let _ = tx.send(Err(status)).await;
+                        return;
+                    }
                 }
             }
 
@@ -456,16 +509,12 @@ impl QuoteLedgerService for LedgerService {
                     continue;
                 }
 
-                let chunk = match inner2
-                    .db({
-                        let q = qid2.clone();
-                        let wm = watermark;
-                        move |c| store::load_stored_events_between(c, &q, wm, head)
-                    })
-                    .await
-                {
+                let chunk = match subscribe_load_between(&inner2, &qid2, watermark, head).await {
                     Ok(c) => c,
-                    Err(_) => continue,
+                    Err(status) => {
+                        let _ = tx.send(Err(status)).await;
+                        break;
+                    }
                 };
 
                 if chunk.is_empty() {
@@ -500,4 +549,21 @@ impl QuoteLedgerService for LedgerService {
 
 pub fn grpc_server(service: LedgerService) -> QuoteLedgerServiceServer<LedgerService> {
     QuoteLedgerServiceServer::new(service)
+}
+
+#[cfg(test)]
+mod subscribe_load_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn subscribe_load_between_empty_range() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("sub.db");
+        let conn = crate::sqlite::open_and_migrate(db.to_str().expect("utf8")).expect("migrate");
+        let inner = LedgerInner::new(conn);
+        let out = subscribe_load_between(&inner, "no-such-quote", 0, 0)
+            .await
+            .expect("ok");
+        assert!(out.is_empty());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,17 @@ pub mod domain;
 pub mod sqlite;
 
 mod auth;
+mod config;
 mod error;
+mod grpc_interceptor;
 mod ledger;
 mod mapping;
 mod store;
 
 pub use auth::AuthInterceptor;
+pub use config::ServiceConfig;
 pub use error::StoreError;
+pub use grpc_interceptor::LedgerGrpcInterceptor;
 pub use ledger::{grpc_server, LedgerService, ReliabilityLimits};
 
 /// gRPC reflection (`grpcurl` / Postman) — generated in `build.rs`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,29 +8,13 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::Router;
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
-use tonic::transport::Server;
-use tonic_reflection::server::Builder as ReflectionBuilder;
-
 use quote_ledger::v1::quote_ledger_service_server::QuoteLedgerServiceServer;
 use quote_ledger::{
-    sqlite, AuthInterceptor, LedgerService, ReliabilityLimits, FILE_DESCRIPTOR_SET,
+    sqlite, AuthInterceptor, LedgerGrpcInterceptor, LedgerService, ServiceConfig,
+    FILE_DESCRIPTOR_SET,
 };
-
-fn env_u64(name: &str, default: u64) -> Result<u64, String> {
-    match std::env::var(name) {
-        Ok(v) => v.parse::<u64>().map_err(|e| format!("{name}: {e}")),
-        Err(std::env::VarError::NotPresent) => Ok(default),
-        Err(std::env::VarError::NotUnicode(_)) => Err(format!("{name}: must be valid UTF-8")),
-    }
-}
-
-fn env_usize(name: &str, default: usize) -> Result<usize, String> {
-    match std::env::var(name) {
-        Ok(v) => v.parse::<usize>().map_err(|e| format!("{name}: {e}")),
-        Err(std::env::VarError::NotPresent) => Ok(default),
-        Err(std::env::VarError::NotUnicode(_)) => Err(format!("{name}: must be valid UTF-8")),
-    }
-}
+use tonic::transport::Server;
+use tonic_reflection::server::Builder as ReflectionBuilder;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -41,15 +25,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         )
         .init();
 
-    let addr = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| "127.0.0.1:50051".to_string())
-        .parse()?;
-
-    let metrics_addr: std::net::SocketAddr = std::env::var("METRICS_ADDR")
-        .unwrap_or_else(|_| "127.0.0.1:9090".into())
-        .parse()
-        .map_err(|e| format!("METRICS_ADDR: {e}"))?;
+    let cfg = ServiceConfig::from_env_and_args().map_err(|e| {
+        Box::<dyn std::error::Error + Send + Sync>::from(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            e,
+        ))
+    })?;
 
     let prometheus = PrometheusBuilder::new()
         .install_recorder()
@@ -59,59 +40,68 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .route("/metrics", get(metrics_scrape))
         .with_state(prometheus);
 
-    let metrics_listener = tokio::net::TcpListener::bind(metrics_addr).await?;
-    tracing::info!(%metrics_addr, "metrics: GET /metrics (Prometheus text format)");
+    let metrics_listener = tokio::net::TcpListener::bind(cfg.metrics_listen).await?;
+    tracing::info!(addr = %cfg.metrics_listen, "metrics: GET /metrics (Prometheus text format)");
     tokio::spawn(async move {
         if let Err(e) = axum::serve(metrics_listener, metrics_app).await {
             tracing::error!(error = %e, "metrics server stopped");
         }
     });
 
-    let db_path = std::env::var("QUOTE_LEDGER_DB").unwrap_or_else(|_| "quote_ledger.db".into());
-    let conn = sqlite::open_and_migrate(&db_path)?;
-    tracing::info!(path = %db_path, "sqlite ready");
+    let conn = sqlite::open_and_migrate(&cfg.db_path)?;
+    tracing::info!(path = %cfg.db_path, "sqlite ready");
 
     let auth = AuthInterceptor::from_env_var("QUOTE_LEDGER_AUTH_TOKEN")
         .map_err(|e| format!("QUOTE_LEDGER_AUTH_TOKEN: {e}"))?;
 
-    let append_idle_timeout_ms = env_u64("APPEND_IDLE_TIMEOUT_MS", 10_000)?;
-    let append_max_commands = env_usize("APPEND_MAX_COMMANDS", 512)?;
-    let grpc_concurrency_limit = env_u64("GRPC_CONCURRENCY_LIMIT", 128)? as usize;
-    let grpc_keepalive_interval_ms = env_u64("GRPC_KEEPALIVE_INTERVAL_MS", 30_000)?;
-    let grpc_keepalive_timeout_ms = env_u64("GRPC_KEEPALIVE_TIMEOUT_MS", 10_000)?;
-
-    let reliability = ReliabilityLimits {
-        append_idle_timeout: Duration::from_millis(append_idle_timeout_ms),
-        append_max_commands,
-    };
-
     tracing::info!(
-        append_idle_timeout_ms,
-        append_max_commands,
-        grpc_concurrency_limit,
-        grpc_keepalive_interval_ms,
-        grpc_keepalive_timeout_ms,
-        "reliability limits configured"
+        grpc = %cfg.grpc_listen,
+        append_idle_timeout_ms = %cfg.reliability.append_idle_timeout.as_millis(),
+        append_max_commands = cfg.reliability.append_max_commands,
+        grpc_concurrency_limit = cfg.grpc_concurrency_limit,
+        grpc_keepalive_interval_ms = %cfg.grpc_keepalive_interval.as_millis(),
+        grpc_keepalive_timeout_ms = %cfg.grpc_keepalive_timeout.as_millis(),
+        reflection_enabled = cfg.reflection_enabled,
+        tls_enabled = cfg.grpc_tls_cert.is_some(),
+        grpc_rate_limit_rps = ?cfg.grpc_rate_limit_rps,
+        "service configuration"
     );
 
-    let ledger_service = LedgerService::with_reliability(conn, reliability);
+    let ledger_service = LedgerService::with_reliability(conn, cfg.reliability.clone());
     let in_flight = ledger_service.in_flight_counter();
-    let ledger = QuoteLedgerServiceServer::with_interceptor(ledger_service, auth);
+    let interceptor = LedgerGrpcInterceptor::new(auth, cfg.grpc_rate_limit_rps);
+    let ledger = QuoteLedgerServiceServer::with_interceptor(ledger_service, interceptor);
 
-    let reflection = ReflectionBuilder::configure()
-        .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
-        .build_v1()?;
+    let mut server_builder = Server::builder()
+        .concurrency_limit_per_connection(cfg.grpc_concurrency_limit)
+        .http2_keepalive_interval(Some(cfg.grpc_keepalive_interval))
+        .http2_keepalive_timeout(Some(cfg.grpc_keepalive_timeout));
 
-    tracing::info!(%addr, "quote_ledger listening (reflection enabled for grpcurl)");
+    if let (Some(cert_path), Some(key_path)) = (&cfg.grpc_tls_cert, &cfg.grpc_tls_key) {
+        let cert = std::fs::read(cert_path)?;
+        let key = std::fs::read(key_path)?;
+        let identity = tonic::transport::Identity::from_pem(cert, key);
+        let tls = tonic::transport::ServerTlsConfig::new().identity(identity);
+        server_builder = server_builder.tls_config(tls)?;
+    }
 
-    Server::builder()
-        .concurrency_limit_per_connection(grpc_concurrency_limit)
-        .http2_keepalive_interval(Some(Duration::from_millis(grpc_keepalive_interval_ms)))
-        .http2_keepalive_timeout(Some(Duration::from_millis(grpc_keepalive_timeout_ms)))
-        .add_service(reflection)
-        .add_service(ledger)
-        .serve_with_shutdown(addr, shutdown_signal(in_flight))
-        .await?;
+    tracing::info!(addr = %cfg.grpc_listen, "quote_ledger listening");
+
+    if cfg.reflection_enabled {
+        let reflection = ReflectionBuilder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()?;
+        server_builder
+            .add_service(reflection)
+            .add_service(ledger)
+            .serve_with_shutdown(cfg.grpc_listen, shutdown_signal(in_flight))
+            .await?;
+    } else {
+        server_builder
+            .add_service(ledger)
+            .serve_with_shutdown(cfg.grpc_listen, shutdown_signal(in_flight))
+            .await?;
+    }
 
     tracing::info!("shutdown complete");
     Ok(())

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -171,5 +171,6 @@ pub fn store_error_to_status(err: crate::error::StoreError) -> Status {
         StoreError::Corrupt(_) => Status::data_loss(err.to_string()),
         StoreError::Sqlite(_) => Status::internal(err.to_string()),
         StoreError::Domain(err) => domain_error_to_status(err),
+        StoreError::IdempotencyConflict { .. } => Status::failed_precondition(err.to_string()),
     }
 }

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -8,5 +8,13 @@ const INITIAL_MIGRATION: &str = include_str!(concat!(
 pub fn open_and_migrate(path: &str) -> Result<Connection, rusqlite::Error> {
     let conn = Connection::open(path)?;
     conn.execute_batch(INITIAL_MIGRATION)?;
+    conn.execute_batch(
+        "
+        PRAGMA foreign_keys = ON;
+        PRAGMA journal_mode = WAL;
+        PRAGMA synchronous = NORMAL;
+        PRAGMA busy_timeout = 5000;
+        ",
+    )?;
     Ok(conn)
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -34,17 +34,6 @@ pub fn load_stored_events(
     Ok(out)
 }
 
-pub fn try_load_idempotent_events(
-    conn: &Connection,
-    quote_id: &str,
-    client_command_id: &str,
-) -> Result<Option<Vec<StoredEvent>>, StoreError> {
-    let Some((first, last)) = idempotency_lookup(conn, quote_id, client_command_id)? else {
-        return Ok(None);
-    };
-    Ok(Some(load_events_in_seq_range(conn, quote_id, first, last)?))
-}
-
 pub fn idempotency_lookup(
     conn: &Connection,
     quote_id: &str,
@@ -90,6 +79,32 @@ fn event_type_for(ev: &QuoteEvent) -> &'static str {
 }
 
 /// Append new events for a command, or return previously stored events if idempotent replay.
+fn encode_quote_event(ev: &QuoteEvent) -> Result<Vec<u8>, StoreError> {
+    let mut buf = Vec::new();
+    ev.encode(&mut buf)
+        .map_err(|e| StoreError::Corrupt(e.to_string()))?;
+    Ok(buf)
+}
+
+fn same_command_payloads(
+    existing: &[StoredEvent],
+    incoming: &[QuoteEvent],
+) -> Result<bool, StoreError> {
+    if existing.len() != incoming.len() {
+        return Ok(false);
+    }
+    for (stored, new_ev) in existing.iter().zip(incoming.iter()) {
+        let old_ev = stored
+            .event
+            .as_ref()
+            .ok_or_else(|| StoreError::Corrupt("stored event missing payload".into()))?;
+        if encode_quote_event(old_ev)? != encode_quote_event(new_ev)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 pub fn append_command_events(
     conn: &mut Connection,
     quote_id: &str,
@@ -97,7 +112,14 @@ pub fn append_command_events(
     events: &[QuoteEvent],
 ) -> Result<Vec<StoredEvent>, StoreError> {
     if let Some((first, last)) = idempotency_lookup(conn, quote_id, client_command_id)? {
-        return load_events_in_seq_range(conn, quote_id, first, last);
+        let existing = load_events_in_seq_range(conn, quote_id, first, last)?;
+        if same_command_payloads(&existing, events)? {
+            return Ok(existing);
+        }
+        return Err(StoreError::IdempotencyConflict {
+            quote_id: quote_id.to_string(),
+            client_command_id: client_command_id.to_string(),
+        });
     }
 
     if events.is_empty() {

--- a/tests/config_strict.rs
+++ b/tests/config_strict.rs
@@ -1,0 +1,27 @@
+//! STRICT_CONFIG rejects unknown QUOTE_LEDGER_* / APPEND_* / GRPC_* keys.
+
+use std::sync::Mutex;
+
+use quote_ledger::ServiceConfig;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn strict_config_rejects_unknown_prefixed_env() {
+    let _g = ENV_LOCK.lock().expect("env lock");
+
+    std::env::set_var("STRICT_CONFIG", "true");
+    std::env::set_var("GRPC_LISTEN_ADDR", "127.0.0.1:59999");
+    std::env::set_var("QUOTE_LEDGER_TYPOS_SHOULD_FAIL", "1");
+
+    let err = ServiceConfig::from_env_and_args().expect_err("strict should fail");
+    assert!(
+        err.contains("unknown environment variable")
+            || err.contains("QUOTE_LEDGER_TYPOS_SHOULD_FAIL"),
+        "unexpected error: {err}"
+    );
+
+    std::env::remove_var("STRICT_CONFIG");
+    std::env::remove_var("QUOTE_LEDGER_TYPOS_SHOULD_FAIL");
+    std::env::remove_var("GRPC_LISTEN_ADDR");
+}

--- a/tests/grpc_rate_limit.rs
+++ b/tests/grpc_rate_limit.rs
@@ -1,0 +1,64 @@
+//! Global gRPC rate limit (GRPC_RATE_LIMIT_RPS) enforced via `LedgerGrpcInterceptor`.
+
+use std::num::NonZeroU32;
+use std::time::Duration;
+
+use quote_ledger::v1::quote_ledger_service_client::QuoteLedgerServiceClient;
+use quote_ledger::v1::quote_ledger_service_server::QuoteLedgerServiceServer;
+use quote_ledger::v1::SubscribeQuoteRequest;
+use quote_ledger::{sqlite, AuthInterceptor, LedgerGrpcInterceptor, LedgerService};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server;
+use tonic::Code;
+
+async fn start_limited_server(rps: NonZeroU32) -> String {
+    let dir = Box::leak(Box::new(tempfile::tempdir().expect("tempdir")));
+    let db = dir.path().join("rate_limit.db");
+    let conn = sqlite::open_and_migrate(db.to_str().expect("utf8 path")).expect("migrate");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let incoming = TcpListenerStream::new(listener);
+
+    let auth = AuthInterceptor::from_env_var("QUOTE_LEDGER_AUTH_TOKEN_UNUSED_FOR_GRPC_RATE_TEST")
+        .expect("auth env");
+    let interceptor = LedgerGrpcInterceptor::new(auth, Some(rps));
+    let svc = QuoteLedgerServiceServer::with_interceptor(LedgerService::new(conn), interceptor);
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(incoming)
+            .await
+            .expect("server");
+    });
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn second_subscribe_hits_global_rate_limit() {
+    let endpoint = start_limited_server(NonZeroU32::new(1).expect("nz")).await;
+    let mut client = QuoteLedgerServiceClient::connect(endpoint)
+        .await
+        .expect("connect");
+
+    let _first = client
+        .subscribe_quote(SubscribeQuoteRequest {
+            quote_id: "q-rate-1".into(),
+            after_seq: 0,
+        })
+        .await
+        .expect("first rpc");
+
+    let err = client
+        .subscribe_quote(SubscribeQuoteRequest {
+            quote_id: "q-rate-1".into(),
+            after_seq: 0,
+        })
+        .await
+        .expect_err("second rpc should be rate limited");
+    assert_eq!(err.code(), Code::ResourceExhausted);
+}

--- a/tests/idempotency_conflict.rs
+++ b/tests/idempotency_conflict.rs
@@ -1,0 +1,91 @@
+//! Idempotency key collision: same client_command_id with different command must fail.
+
+use std::time::Duration;
+
+use quote_ledger::v1::quote_command::Kind as CmdKind;
+use quote_ledger::v1::quote_ledger_service_client::QuoteLedgerServiceClient;
+use quote_ledger::v1::{AddLineItem, AppendCommandRequest, CreateQuote, QuoteCommand};
+use quote_ledger::{grpc_server, sqlite, LedgerService};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Channel;
+use tonic::transport::Server;
+use tonic::Code;
+
+async fn append_one(
+    client: &mut QuoteLedgerServiceClient<Channel>,
+    quote_id: &str,
+    client_command_id: &str,
+    cmd: QuoteCommand,
+) -> Result<(), tonic::Status> {
+    let (tx, rx) = tokio::sync::mpsc::channel::<AppendCommandRequest>(2);
+    tx.send(AppendCommandRequest {
+        client_command_id: client_command_id.into(),
+        quote_id: quote_id.into(),
+        command: Some(cmd),
+    })
+    .await
+    .expect("send");
+    drop(tx);
+    client.append_commands(ReceiverStream::new(rx)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn idempotency_conflict_on_same_key_different_command() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("idem.db");
+    let conn = sqlite::open_and_migrate(db.to_str().expect("utf8")).expect("migrate");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let incoming = TcpListenerStream::new(listener);
+    let svc = grpc_server(LedgerService::new(conn));
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(incoming)
+            .await
+            .expect("server");
+    });
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let mut client = QuoteLedgerServiceClient::connect(format!("http://{addr}"))
+        .await
+        .expect("connect");
+    let quote_id = "q-idem-1";
+
+    append_one(
+        &mut client,
+        quote_id,
+        "same-key",
+        QuoteCommand {
+            kind: Some(CmdKind::CreateQuote(CreateQuote {
+                currency_code: "USD".into(),
+                jurisdiction_id: "US-CA".into(),
+            })),
+        },
+    )
+    .await
+    .expect("first append");
+
+    let err = append_one(
+        &mut client,
+        quote_id,
+        "same-key",
+        QuoteCommand {
+            kind: Some(CmdKind::AddLineItem(AddLineItem {
+                line_id: "L1".into(),
+                sku: "SKU".into(),
+                description: "Widget".into(),
+                quantity: 1,
+                unit_minor: 100,
+            })),
+        },
+    )
+    .await
+    .expect_err("conflicting idempotency payload");
+
+    assert_eq!(err.code(), Code::FailedPrecondition);
+}

--- a/tests/soak_concurrent.rs
+++ b/tests/soak_concurrent.rs
@@ -1,0 +1,131 @@
+//! Longer soak-style concurrency test (ignored in default CI).
+
+use std::time::Duration;
+
+use quote_ledger::v1::quote_command::Kind as CmdKind;
+use quote_ledger::v1::quote_ledger_service_client::QuoteLedgerServiceClient;
+use quote_ledger::v1::quote_update::Kind as UpdateKind;
+use quote_ledger::v1::{
+    AddLineItem, AppendCommandRequest, CreateQuote, QuoteCommand, SubscribeQuoteRequest,
+};
+use quote_ledger::{grpc_server, sqlite, LedgerService};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Channel;
+use tonic::transport::Server;
+
+async fn append_one(
+    client: &mut QuoteLedgerServiceClient<Channel>,
+    quote_id: &str,
+    client_command_id: &str,
+    cmd: QuoteCommand,
+) {
+    let (tx, rx) = tokio::sync::mpsc::channel::<AppendCommandRequest>(4);
+    tx.send(AppendCommandRequest {
+        client_command_id: client_command_id.into(),
+        quote_id: quote_id.into(),
+        command: Some(cmd),
+    })
+    .await
+    .expect("send");
+    drop(tx);
+    client
+        .append_commands(ReceiverStream::new(rx))
+        .await
+        .expect("append");
+}
+
+#[tokio::test]
+#[ignore = "long-running soak; run manually: cargo test -p quote_ledger soak_many_parallel_line_items -- --ignored"]
+async fn soak_many_parallel_line_items() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("soak.db");
+    let conn = sqlite::open_and_migrate(db.to_str().expect("utf8")).expect("migrate");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let incoming = TcpListenerStream::new(listener);
+    let svc = grpc_server(LedgerService::new(conn));
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(incoming)
+            .await
+            .expect("server");
+    });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let endpoint = format!("http://{addr}");
+    let mut bootstrap = QuoteLedgerServiceClient::connect(endpoint.clone())
+        .await
+        .expect("connect");
+    let quote_id = "q-soak-1";
+
+    append_one(
+        &mut bootstrap,
+        quote_id,
+        "create",
+        QuoteCommand {
+            kind: Some(CmdKind::CreateQuote(CreateQuote {
+                currency_code: "USD".into(),
+                jurisdiction_id: "US-CA".into(),
+            })),
+        },
+    )
+    .await;
+
+    const N: usize = 128;
+    let mut join_set = tokio::task::JoinSet::new();
+    for i in 0..N {
+        let ep = endpoint.clone();
+        let q = quote_id.to_string();
+        join_set.spawn(async move {
+            let mut c = QuoteLedgerServiceClient::connect(ep)
+                .await
+                .expect("connect");
+            append_one(
+                &mut c,
+                &q,
+                &format!("line-{i}"),
+                QuoteCommand {
+                    kind: Some(CmdKind::AddLineItem(AddLineItem {
+                        line_id: format!("L{i}"),
+                        sku: "SKU".into(),
+                        description: "Soak".into(),
+                        quantity: 1,
+                        unit_minor: 1,
+                    })),
+                },
+            )
+            .await;
+        });
+    }
+    while let Some(r) = join_set.join_next().await {
+        r.expect("writer");
+    }
+
+    let mut reader = QuoteLedgerServiceClient::connect(endpoint)
+        .await
+        .expect("connect");
+    let mut sub = reader
+        .subscribe_quote(SubscribeQuoteRequest {
+            quote_id: quote_id.into(),
+            after_seq: 0,
+        })
+        .await
+        .expect("subscribe")
+        .into_inner();
+
+    let mut saw = false;
+    while let Some(msg) = sub.message().await.expect("stream") {
+        if let UpdateKind::Snapshot(s) = msg.kind.expect("kind") {
+            assert_eq!(s.last_seq, (N + 1) as u64);
+            let v = s.view.expect("view");
+            assert_eq!(v.line_items.len(), N);
+            saw = true;
+            break;
+        }
+    }
+    assert!(saw);
+}


### PR DESCRIPTION
## Summary

Delivers the **v1.2 production hardening** backlog: subscribe correctness and metrics, centralized config and safety rails, optional TLS/reflection/rate limiting, SQLite pragmas, idempotency conflict semantics and replay fix, ops and client docs, and expanded tests.

**Not claimed closed:** [#38](https://github.com/jparrott06/quote-ledger/issues/38) (L-03 deterministic paused-clock coverage for idle-timeout tests) — `tokio` `test-util` is available; a dedicated paused test can follow.

## Local verification

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo build --release`

Closes #19
Closes #20
Closes #21
Closes #22
Closes #23
Closes #24
Closes #25
Closes #26
Closes #27
Closes #28
Closes #29
Closes #30
Closes #31
Closes #32
Closes #33
Closes #34
Closes #35
Closes #36
Closes #37
Closes #39
Closes #40
Closes #41
