### PR TITLE
fix: auth-first rate limiting and append transport-error metrics

### DIFF
--- a/src/grpc_interceptor.rs
+++ b/src/grpc_interceptor.rs
@@ -1,4 +1,4 @@
-//! Composite gRPC interceptor: optional process-wide request rate limit, then auth.
+//! Composite gRPC interceptor: auth first, then optional process-wide request rate limit.
 
 use std::num::NonZeroU32;
 use std::sync::Arc;
@@ -31,6 +31,7 @@ impl LedgerGrpcInterceptor {
 
 impl Interceptor for LedgerGrpcInterceptor {
     fn call(&mut self, request: Request<()>) -> Result<Request<()>, Status> {
+        let request = self.auth.intercept(request)?;
         if let Some(lim) = &self.limiter {
             if lim.check().is_err() {
                 counter!("quote_ledger_grpc_rate_limited_total").increment(1);
@@ -39,7 +40,7 @@ impl Interceptor for LedgerGrpcInterceptor {
                 ));
             }
         }
-        self.auth.intercept(request)
+        Ok(request)
     }
 }
 

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -300,7 +300,11 @@ impl QuoteLedgerService for LedgerService {
             {
                 Ok(Ok(Some(m))) => m,
                 Ok(Ok(None)) => break,
-                Ok(Err(e)) => return Err(e),
+                Ok(Err(e)) => {
+                    counter!("quote_ledger_append_commands_streams_total", "result" => "transport_error")
+                        .increment(1);
+                    return Err(e);
+                }
                 Err(_) => {
                     counter!("quote_ledger_append_commands_streams_total", "result" => "timeout")
                         .increment(1);

--- a/tests/grpc_rate_limit.rs
+++ b/tests/grpc_rate_limit.rs
@@ -9,10 +9,12 @@ use quote_ledger::v1::SubscribeQuoteRequest;
 use quote_ledger::{sqlite, AuthInterceptor, LedgerGrpcInterceptor, LedgerService};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
+use tonic::metadata::MetadataValue;
 use tonic::transport::Server;
 use tonic::Code;
+use tonic::Request;
 
-async fn start_limited_server(rps: NonZeroU32) -> String {
+async fn start_limited_server(rps: NonZeroU32, auth_token: Option<&str>) -> String {
     let dir = Box::leak(Box::new(tempfile::tempdir().expect("tempdir")));
     let db = dir.path().join("rate_limit.db");
     let conn = sqlite::open_and_migrate(db.to_str().expect("utf8 path")).expect("migrate");
@@ -21,8 +23,11 @@ async fn start_limited_server(rps: NonZeroU32) -> String {
     let addr = listener.local_addr().expect("addr");
     let incoming = TcpListenerStream::new(listener);
 
-    let auth = AuthInterceptor::from_env_var("QUOTE_LEDGER_AUTH_TOKEN_UNUSED_FOR_GRPC_RATE_TEST")
-        .expect("auth env");
+    let auth = match auth_token {
+        Some(token) => AuthInterceptor::required(token),
+        None => AuthInterceptor::from_env_var("QUOTE_LEDGER_AUTH_TOKEN_UNUSED_FOR_GRPC_RATE_TEST")
+            .expect("auth env"),
+    };
     let interceptor = LedgerGrpcInterceptor::new(auth, Some(rps));
     let svc = QuoteLedgerServiceServer::with_interceptor(LedgerService::new(conn), interceptor);
 
@@ -40,7 +45,7 @@ async fn start_limited_server(rps: NonZeroU32) -> String {
 
 #[tokio::test]
 async fn second_subscribe_hits_global_rate_limit() {
-    let endpoint = start_limited_server(NonZeroU32::new(1).expect("nz")).await;
+    let endpoint = start_limited_server(NonZeroU32::new(1).expect("nz"), None).await;
     let mut client = QuoteLedgerServiceClient::connect(endpoint)
         .await
         .expect("connect");
@@ -61,4 +66,34 @@ async fn second_subscribe_hits_global_rate_limit() {
         .await
         .expect_err("second rpc should be rate limited");
     assert_eq!(err.code(), Code::ResourceExhausted);
+}
+
+#[tokio::test]
+async fn unauthenticated_request_does_not_consume_rate_limit_budget() {
+    let endpoint =
+        start_limited_server(NonZeroU32::new(1).expect("nz"), Some("secret-token")).await;
+    let mut client = QuoteLedgerServiceClient::connect(endpoint)
+        .await
+        .expect("connect");
+
+    let unauth_err = client
+        .subscribe_quote(SubscribeQuoteRequest {
+            quote_id: "q-rate-2".into(),
+            after_seq: 0,
+        })
+        .await
+        .expect_err("missing auth should fail");
+    assert_eq!(unauth_err.code(), Code::Unauthenticated);
+
+    let mut req = Request::new(SubscribeQuoteRequest {
+        quote_id: "q-rate-2".into(),
+        after_seq: 0,
+    });
+    req.metadata_mut().insert(
+        "authorization",
+        MetadataValue::from_static("Bearer secret-token"),
+    );
+    let _ok = client.subscribe_quote(req).await.expect(
+        "authorized request should still pass (unauthenticated call must not consume limiter budget)",
+    );
 }


### PR DESCRIPTION
## Summary
- Run authentication before global gRPC rate limiting so unauthenticated traffic cannot consume valid-client quota.
- Add `quote_ledger_append_commands_streams_total{result=\"transport_error\"}` when append stream transport reads fail.
- Add integration coverage that unauthenticated calls do not consume the rate-limit budget.

## Test plan
- [x] cargo fmt --all
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test --all
- [x] cargo build --release

Made with [Cursor](https://cursor.com)